### PR TITLE
fix typo in the instructions

### DIFF
--- a/plugin/unicycle.vim
+++ b/plugin/unicycle.vim
@@ -8,7 +8,7 @@
 " works if set encoding=utf-8.
 "
 " To install, drop it in your plugins directory. To use, execute the
-" :UniCycleOn command. Turn turn it off, execute :UniCycleOff.
+" :UniCycleOn command. To turn it off, execute :UniCycleOff.
 "
 " When on, the hyphen (-), period (.), apostrophe ('), and quote (")
 " characters are mapped to the appropriate functions within this file.


### PR DESCRIPTION
Hi Jason,

After many years free from bug-reports, it seems I've discovered the sole (insignificant) flaw in this simple but great Vim plugin. :)

As a fan of typographically correct punctuation, I've been happily using UniCycle (great name, BTW) since I discovered it a month ago. It's so much more convenient than having to check the docs to find out the correct digraph.

Regards,
Anthony
